### PR TITLE
[FEATURE] Use a service to hold the menu state

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,12 +212,14 @@ The `{{burger-menu}}` component exposes multiple contextual components, but it a
 {{/burger-menu}}
 ```
 
-### Via Import
+### Via Service
 
-If you need a more programmatic solution, you can grab the menu state via a simple import.
+If you need a more programmatic solution, you can grab the menu state via injecting the `burgerMenu` service.
 
 ```js
-import burgerMenu from 'ember-burger-menu';
+export default Ember.Component.extend({
+  burgerMenu: Ember.inject.service()
+})
 ```
 
 ### Usage

--- a/addon/components/bm-menu-item.js
+++ b/addon/components/bm-menu-item.js
@@ -5,7 +5,8 @@ import computedStyleFor from 'ember-burger-menu/computed/style-for';
 const {
   $,
   run,
-  computed
+  computed,
+  inject: { service }
 } = Ember;
 
 export default Ember.Component.extend({
@@ -13,7 +14,8 @@ export default Ember.Component.extend({
   classNames: ['bm-menu-item'],
   attributeBindings: ['style'],
 
-  state: null,
+  state: service('burgerMenu'),
+
   menuItems: null,
   dismissOnClick: false,
   style: computedStyleFor('menuItem').readOnly(),

--- a/addon/components/bm-menu.js
+++ b/addon/components/bm-menu.js
@@ -5,7 +5,8 @@ import computedStyleFor from 'ember-burger-menu/computed/style-for';
 const {
   computed,
   observer,
-  A: emberArray
+  A: emberArray,
+  inject: { service }
 } = Ember;
 
 export const OUTLET_MENU_ANIMATIONS = [
@@ -15,8 +16,8 @@ export const OUTLET_MENU_ANIMATIONS = [
 
 export default Ember.Component.extend({
   layout,
+  state: service('burgerMenu'),
 
-  state: null,
   itemTagName: 'div',
   dismissOnItemClick: false,
 

--- a/addon/components/bm-outlet.js
+++ b/addon/components/bm-outlet.js
@@ -2,11 +2,14 @@ import Ember from 'ember';
 import layout from '../templates/components/bm-outlet';
 import computedStyleFor from 'ember-burger-menu/computed/style-for';
 
+const {
+  inject: { service }
+} = Ember;
+
 export default Ember.Component.extend({
   layout,
   classNames: ['bm-outlet'],
   attributeBindings: ['style'],
-
-  state: null,
+  state: service('burgerMenu'),
   style: computedStyleFor('outlet').readOnly()
 });

--- a/addon/components/burger-menu.js
+++ b/addon/components/burger-menu.js
@@ -91,7 +91,7 @@ export default Ember.Component.extend(SwipeSupport, {
   onSwipe(direction, target) {
     let position = this.get('position');
     let open = this.get('open');
-    let isMenuSwipe = target.closest('.bm-menu').length > 0;
+    let isMenuSwipe = $(target).closest('.bm-menu').length > 0;
 
     if (open && isMenuSwipe && position === direction) {
       this.set('open', false);

--- a/addon/components/burger-menu.js
+++ b/addon/components/burger-menu.js
@@ -1,6 +1,5 @@
 import Ember from 'ember';
 import layout from '../templates/components/burger-menu';
-import state from 'ember-burger-menu';
 import computedStyleFor from 'ember-burger-menu/computed/style-for';
 import SwipeSupport from 'ember-burger-menu/mixins/swipe-support';
 
@@ -10,7 +9,8 @@ const {
   run,
   observer,
   computed,
-  computed: { alias }
+  computed: { alias },
+  inject: { service }
 } = Ember;
 
 export default Ember.Component.extend(SwipeSupport, {
@@ -18,7 +18,8 @@ export default Ember.Component.extend(SwipeSupport, {
   classNameBindings: ['open:is-open', 'translucentOverlay', 'animationClass', 'position'],
   attributeBindings: ['style'],
   layout,
-  state,
+
+  state: service('burgerMenu'),
 
   translucentOverlay: true,
   dismissOnClick: true,

--- a/addon/index.js
+++ b/addon/index.js
@@ -1,3 +1,0 @@
-import MenuState from 'ember-burger-menu/-private/menu-state';
-
-export default MenuState.create();

--- a/addon/mixins/swipe-support.js
+++ b/addon/mixins/swipe-support.js
@@ -1,7 +1,6 @@
 import Ember from 'ember';
 
 const {
-  $,
   isNone
 } = Ember;
 
@@ -21,7 +20,7 @@ export default Ember.Mixin.create({
     // jscs:enable
 
     meta = {
-      target: $(e.target),
+      target: e.target,
       start: {
         x: touch.pageX,
         y: touch.pageY,

--- a/addon/services/burger-menu.js
+++ b/addon/services/burger-menu.js
@@ -5,7 +5,7 @@ const {
   computed
 } = Ember;
 
-export default Ember.Object.extend({
+export default Ember.Service.extend({
   open: false,
   width: 300,
   position: 'left',
@@ -23,9 +23,9 @@ export default Ember.Object.extend({
 
   actions: computed(function() {
     return {
-      open: this.set.bind(this, 'open', true),
-      close: this.set.bind(this, 'open', false),
-      toggle: this.toggleProperty.bind(this, 'open')
+      open: () => this.set('open', true),
+      close: () => this.set('open', false),
+      toggle: () => this.toggleProperty('open')
     };
   }).readOnly()
 });

--- a/addon/templates/components/bm-menu.hbs
+++ b/addon/templates/components/bm-menu.hbs
@@ -4,8 +4,7 @@
         item=(component 'bm-menu-item'
           tagName=itemTagName
           menuItems=menuItems
-          dismissOnClick=dismissOnItemClick
-          state=state)
+          dismissOnClick=dismissOnItemClick)
       )
     }}
   </div>

--- a/addon/templates/components/burger-menu.hbs
+++ b/addon/templates/components/burger-menu.hbs
@@ -1,6 +1,6 @@
 {{yield (hash
-    outlet=(component 'bm-outlet' containerId=elementId state=state)
-    menu=(component 'bm-menu' containerId=elementId state=state)
+    outlet=(component 'bm-outlet' containerId=elementId)
+    menu=(component 'bm-menu' containerId=elementId)
     state=state
   )
 }}

--- a/app/services/burger-menu.js
+++ b/app/services/burger-menu.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-burger-menu/services/burger-menu';

--- a/tests/dummy/app/controllers/index.js
+++ b/tests/dummy/app/controllers/index.js
@@ -1,5 +1,4 @@
 import Ember from 'ember';
-import burgerMenu from 'ember-burger-menu';
 
 const {
   inject,
@@ -17,7 +16,7 @@ export default Ember.Controller.extend({
   ],
 
   application: inject.controller(),
-  burgerMenu,
+  burgerMenu: inject.service(),
 
   animation: computed.alias('burgerMenu.animation'),
   itemAnimation: computed.alias('burgerMenu.itemAnimation'),

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -5,7 +5,7 @@
   as |burger|
 }}
   {{#burger.menu itemTagName="li" dismissOnItemClick=true as |menu|}}
-    <a {{action burger.state.actions.toggle}} class="close {{burger.state.position}} fa fa-times"></a>
+    <a {{action burger.state.actions.close}} class="close {{burger.state.position}} fa fa-times"></a>
     <h2><i class="fa fa-bars" aria-hidden="true"></i> Menu</h2>
 
     <ul>

--- a/tests/integration/components/bm-menu-item-test.js
+++ b/tests/integration/components/bm-menu-item-test.js
@@ -1,10 +1,10 @@
 import Ember from 'ember';
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
-import MenuState from 'ember-burger-menu/-private/menu-state';
 
 const {
   run,
+  getOwner,
   A: emberArray
 } = Ember;
 
@@ -20,7 +20,7 @@ moduleForComponent('bm-menu-item', 'Integration | Component | bm menu item', {
   beforeEach() {
     this.setProperties({
       menuItems: emberArray([]),
-      state: MenuState.create(),
+      state: getOwner(this).lookup('service:burger-menu'),
       dismissOnClick: false
     });
   }

--- a/tests/integration/components/bm-menu-item-test.js
+++ b/tests/integration/components/bm-menu-item-test.js
@@ -9,7 +9,7 @@ const {
 } = Ember;
 
 const template = hbs`
-  {{#bm-menu-item state=state menuItems=menuItems dismissOnClick=dismissOnClick}}
+  {{#bm-menu-item menuItems=menuItems dismissOnClick=dismissOnClick}}
     Content
   {{/bm-menu-item}}
 `;

--- a/tests/integration/components/bm-menu-test.js
+++ b/tests/integration/components/bm-menu-test.js
@@ -2,10 +2,10 @@ import Ember from 'ember';
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 import Animation from 'ember-burger-menu/animations/base';
-import MenuState from 'ember-burger-menu/-private/menu-state';
 
 const {
-  run
+  run,
+  getOwner
 } = Ember;
 
 const template = hbs`
@@ -34,7 +34,7 @@ moduleForComponent('bm-menu', 'Integration | Component | bm menu', {
 
   beforeEach() {
     this.setProperties({
-      state: MenuState.create(),
+      state: getOwner(this).lookup('service:burger-menu'),
       itemTagName: 'li'
     });
   }

--- a/tests/integration/components/bm-menu-test.js
+++ b/tests/integration/components/bm-menu-test.js
@@ -10,7 +10,6 @@ const {
 
 const template = hbs`
   {{#bm-menu
-    state=state
     itemTagName=itemTagName
     as |menu|
   }}

--- a/tests/integration/components/bm-outlet-test.js
+++ b/tests/integration/components/bm-outlet-test.js
@@ -1,6 +1,10 @@
+import Ember from 'ember';
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
-import MenuState from 'ember-burger-menu/-private/menu-state';
+
+const {
+  getOwner
+} = Ember;
 
 const template = hbs`
   {{#bm-outlet state=state}}
@@ -13,7 +17,7 @@ moduleForComponent('bm-outlet', 'Integration | Component | bm outlet', {
 
   beforeEach() {
     this.setProperties({
-      state: MenuState.create()
+      state: getOwner(this).lookup('service:burger-menu')
     });
   }
 });

--- a/tests/integration/components/burger-menu-test.js
+++ b/tests/integration/components/burger-menu-test.js
@@ -2,12 +2,12 @@ import Ember from 'ember';
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 import Animation from 'ember-burger-menu/animations/base';
-import MenuState from 'ember-burger-menu/-private/menu-state';
 import triggerKeyboardEvent, { KEYS } from '../../helpers/trigger-keyboard-event';
 import triggerSwipeEvent from '../../helpers/trigger-swipe-event';
 
 const {
-  run
+  run,
+  getOwner
 } = Ember;
 
 const template = hbs`
@@ -61,7 +61,7 @@ moduleForComponent('burger-menu', 'Integration | Component | burger menu', {
       translucentOverlay: true,
       dismissOnClick: true,
       dismissOnEsc: true,
-      state: MenuState.create()
+      state: getOwner(this).lookup('service:burger-menu')
     });
   }
 });

--- a/tests/integration/components/burger-menu-test.js
+++ b/tests/integration/components/burger-menu-test.js
@@ -15,7 +15,6 @@ const template = hbs`
     translucentOverlay=translucentOverlay
     dismissOnClick=dismissOnClick
     dismissOnEsc=dismissOnEsc
-    state=state
     open=open
     as |burger|
   }}

--- a/tests/unit/services/burger-menu-test.js
+++ b/tests/unit/services/burger-menu-test.js
@@ -1,0 +1,12 @@
+import { moduleFor, test } from 'ember-qunit';
+
+moduleFor('service:burger-menu', 'Unit | Service | burger menu', {
+  // Specify the other units that are required for this test.
+  // needs: ['service:foo']
+});
+
+// Replace this with your real tests.
+test('it exists', function(assert) {
+  let service = this.subject();
+  assert.ok(service);
+});


### PR DESCRIPTION
Using a service instead of an exported Ember.Object is a much cleaner solution. The state also gets cleaned up correctly between each test case and is easier to maintain. 

Before:

```js
import burgerMenu from 'ember-burger-menu';
```

After:

```js
export default Ember.Component.extend({
  burgerMenu: Ember.inject.service()
});
```