### PR TITLE
[FEATURE] Locked + gesturesEnabled + use ember-lifeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,13 @@ This addon utilizes contextual components to be able to correctly control and an
 
   **Default: 300**
 
+- #### `locked`
+
+  Lock the menu in its current open / closed state. Please note that changes made
+  directly via the burgerMenu service or {{burger.state.actions}} will still propagate.
+
+  **Default: false**
+
 - #### `customAnimation`
 
   Override of the menu's styles with your own implementation. See [Custom Animations](#custom-animations) for more details.
@@ -139,6 +146,12 @@ This addon utilizes contextual components to be able to correctly control and an
 - #### `dismissOnEsc`
 
   Whether the menu can be closed when pressing the ESC key.
+
+  **Default: true**
+
+- #### `gesturesEnabled`
+
+  Whether the menu can be open / closed using gestures. The only available gesture currently is swipe.
 
   **Default: true**
 

--- a/addon/components/bm-menu-item.js
+++ b/addon/components/bm-menu-item.js
@@ -36,7 +36,7 @@ export default Ember.Component.extend({
   },
 
   click() {
-    if (this.get('dismissOnClick')) {
+    if (this.get('dismissOnClick') && !this.get('state.locked')) {
       this.set('state.open', false);
     }
   }

--- a/addon/mixins/swipe-support.js
+++ b/addon/mixins/swipe-support.js
@@ -1,14 +1,17 @@
 import Ember from 'ember';
 
 const {
-  isNone
+  isNone,
+  inject: { service },
+  computed: { alias }
 } = Ember;
 
 let meta;
 
 export default Ember.Mixin.create({
-  minSwipeDistance: 150,
-  maxSwipeTime: 300,
+  state: service('burgerMenu'),
+  minSwipeDistance: alias('state.minSwipeDistance'),
+  maxSwipeTime: alias('state.maxSwipeTime'),
 
   onSwipe(/* direction, target */) {},
 

--- a/addon/services/burger-menu.js
+++ b/addon/services/burger-menu.js
@@ -7,9 +7,14 @@ const {
 
 export default Ember.Service.extend({
   open: false,
+  locked: false,
   width: 300,
   position: 'left',
   animation: 'slide',
+
+  minSwipeDistance: 150,
+  maxSwipeTime: 300,
+
   itemAnimation: null,
   customAnimation: null,
 

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "ember-cli-babel": "^5.1.7",
     "ember-cli-htmlbars": "^1.0.10",
     "ember-cli-sass": "^5.6.0",
+    "ember-lifeline": "rwjblue/ember-lifeline#master",
     "ember-require-module": "^0.1.1",
     "ember-wormhole": "^0.5.0"
   },

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "ember-cli-babel": "^5.1.7",
     "ember-cli-htmlbars": "^1.0.10",
     "ember-cli-sass": "^5.6.0",
-    "ember-lifeline": "rwjblue/ember-lifeline#master",
+    "ember-lifeline": "^1.0.4",
     "ember-require-module": "^0.1.1",
     "ember-wormhole": "^0.5.0"
   },

--- a/tests/dummy/app/controllers/application.js
+++ b/tests/dummy/app/controllers/application.js
@@ -3,5 +3,6 @@ import Ember from 'ember';
 export default Ember.Controller.extend({
   translucentOverlay: true,
   dismissOnClick: true,
-  dismissOnEsc: true
+  dismissOnEsc: true,
+  gesturesEnabled: true
 });

--- a/tests/dummy/app/controllers/index.js
+++ b/tests/dummy/app/controllers/index.js
@@ -2,7 +2,7 @@ import Ember from 'ember';
 
 const {
   inject,
-  computed
+  computed: { alias }
 } = Ember;
 
 export default Ember.Controller.extend({
@@ -10,21 +10,25 @@ export default Ember.Controller.extend({
     'animation',
     'itemAnimation',
     'position',
+    'locked',
     'translucentOverlay',
     'dismissOnClick',
-    'dismissOnEsc'
+    'dismissOnEsc',
+    'gesturesEnabled'
   ],
 
   application: inject.controller(),
   burgerMenu: inject.service(),
 
-  animation: computed.alias('burgerMenu.animation'),
-  itemAnimation: computed.alias('burgerMenu.itemAnimation'),
-  position: computed.alias('burgerMenu.position'),
+  animation: alias('burgerMenu.animation'),
+  itemAnimation: alias('burgerMenu.itemAnimation'),
+  position: alias('burgerMenu.position'),
+  locked: alias('burgerMenu.locked'),
 
-  translucentOverlay: computed.alias('application.translucentOverlay'),
-  dismissOnClick: computed.alias('application.dismissOnClick'),
-  dismissOnEsc: computed.alias('application.dismissOnEsc'),
+  translucentOverlay: alias('application.translucentOverlay'),
+  dismissOnClick: alias('application.dismissOnClick'),
+  dismissOnEsc: alias('application.dismissOnEsc'),
+  gesturesEnabled: alias('application.gesturesEnabled'),
 
   animations: [
     'slide',

--- a/tests/dummy/app/styles/app.scss
+++ b/tests/dummy/app/styles/app.scss
@@ -34,6 +34,10 @@ a {
   }
 }
 
+::-webkit-scrollbar {
+    display: none;
+}
+
 .pointer {
   cursor: pointer;
 }
@@ -185,64 +189,82 @@ a {
   }
 }
 
-.header {
-  background: #233040;
-  padding-top: 60px;
+main {
+  height: 100%;
 
-  h1 {
-    font-family: 'Bungee Hairline', cursive;
-    font-weight: bold;
-  }
+  .header {
+    background: #233040;
+    padding: 10px;
+    height: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex-direction: column;
 
-  .description {
-    padding: 30px 0 30px;
-    font-size: 16px;
-
-    > p {
-      max-width: 500px;
-      margin: 0 auto;
+    img {
+      width: 375px;
+      max-width: 80%;
     }
-  }
-}
 
-.container {
-  padding-top: 30px;
-
-  h4 {
-    margin-bottom: 20px;
-    font-size: 16px;
-    font-weight: 400;
-  }
-
-  .animations {
-    min-height: 225px;
-    border-right: 1px solid #ccc;
-    padding-right: 25px;
-
-    .btn-outline {
-      margin: 0 0 10px 10px;
+    h1 {
+      font-family: 'Bungee Hairline', cursive;
+      font-weight: bold;
     }
-  }
 
-  .options {
-    min-height: 225px;
-    padding-left: 25px;
+    .description {
+      padding: 30px 0 30px;
+      font-size: 16px;
 
-    .option {
-      label {
-        font-size: 15px;
-        width: 160px;
-      }
-      .checkbox {
-        cursor: pointer;
-        display: inline-block;
-        color: $accent-color;
-        font-size: 18px;
+      > p {
+        max-width: 500px;
+        margin: 0 auto;
       }
     }
   }
-}
 
-.inspiration {
-  padding: 40px 0;
+  .content {
+    height: 50%;
+
+    .container {
+      padding-top: 30px;
+
+      h4 {
+        margin-bottom: 20px;
+        font-size: 16px;
+        font-weight: 400;
+      }
+
+      .animations {
+        min-height: 310px;
+        border-right: 1px solid #ccc;
+        padding-right: 25px;
+
+        .btn-outline {
+          margin: 0 0 10px 10px;
+        }
+      }
+
+      .options {
+        min-height: 310px;
+        padding-left: 25px;
+
+        .option {
+          label {
+            font-size: 15px;
+            width: 160px;
+          }
+          .checkbox {
+            cursor: pointer;
+            display: inline-block;
+            color: $accent-color;
+            font-size: 18px;
+          }
+        }
+      }
+    }
+
+    .inspiration {
+      padding: 40px 0;
+    }
+  }
 }

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -2,6 +2,7 @@
   translucentOverlay=translucentOverlay
   dismissOnClick=dismissOnClick
   dismissOnEsc=dismissOnEsc
+  gesturesEnabled=gesturesEnabled
   as |burger|
 }}
   {{#burger.menu itemTagName="li" dismissOnItemClick=true as |menu|}}

--- a/tests/dummy/app/templates/index.hbs
+++ b/tests/dummy/app/templates/index.hbs
@@ -1,73 +1,91 @@
-<div class="header clear-both text-center">
-    <img src="images/ember-logo.png" width="375px" ondragstart="return false;"/>
-    <h1>Burger Menu</h1>
+<main class="text-center">
+  <div class="header">
+      <img src="images/ember-logo.png" ondragstart="return false;"/>
+      <h1>Burger Menu</h1>
 
-    <div class="description text-center">
-      <p>
-        An off-canvas sidebar component with a collection of animations and styles using CSS transitions.
-      </p>
-    </div>
-</div>
-
-<div class="container">
-  <div class="col-xs-6 animations text-right">
-    <h4>Animations</h4>
-    {{#each animations as |animation|}}
-      <button class="btn btn-default btn-outline {{if (eq animation burgerMenu.animation) 'active'}}" {{action 'setMenu' 'animation' animation}}>
-        {{titleize (dedasherize animation)}}
-      </button>
-    {{/each}}
-
-    <h4>Item Animations</h4>
-    <button class="btn btn-default btn-outline {{if (not burgerMenu.itemAnimation)'active'}}" {{action 'setMenu' 'itemAnimation' null}}>
-      None
-    </button>
-    {{#each itemAnimations as |animation|}}
-      <button class="btn btn-default btn-outline {{if (eq animation burgerMenu.itemAnimation) 'active'}}" {{action 'setMenu' 'itemAnimation' animation}}>
-        {{titleize (dedasherize animation)}}
-      </button>
-    {{/each}}
+      <div class="description">
+        <p>
+          An off-canvas sidebar component with a collection of animations and styles using CSS transitions.
+        </p>
+      </div>
   </div>
 
-  <div class="col-xs-6 options text-left">
-    <h4>Options</h4>
+  <div class="content">
+    <div class="container">
+      <div class="col-xs-6 animations text-right">
+        <h4>Animations</h4>
+        {{#each animations as |animation|}}
+          <button class="btn btn-default btn-outline {{if (eq animation burgerMenu.animation) 'active'}}" {{action 'setMenu' 'animation' animation}}>
+            {{titleize (dedasherize animation)}}
+          </button>
+        {{/each}}
 
-    <div class="option">
-      <label for="position">Position</label>
-      <div class="btn-group" role="group" id="position">
-        {{#each (array 'left' 'right') as |position|}}
-          <button type="button" class="btn btn-default btn-outline {{if (eq position burgerMenu.position) 'active'}}" {{action 'setMenu' 'position' position}}>
-            {{titleize position}}
+        <h4>Item Animations</h4>
+        <button class="btn btn-default btn-outline {{if (not burgerMenu.itemAnimation)'active'}}" {{action 'setMenu' 'itemAnimation' null}}>
+          None
+        </button>
+        {{#each itemAnimations as |animation|}}
+          <button class="btn btn-default btn-outline {{if (eq animation burgerMenu.itemAnimation) 'active'}}" {{action 'setMenu' 'itemAnimation' animation}}>
+            {{titleize (dedasherize animation)}}
           </button>
         {{/each}}
       </div>
+
+      <div class="col-xs-6 options text-left">
+        <h4>Options</h4>
+
+        <div class="option">
+          <label for="position">Position</label>
+          <div class="btn-group" role="group" id="position">
+            {{#each (array 'left' 'right') as |position|}}
+              <button type="button" class="btn btn-default btn-outline {{if (eq position burgerMenu.position) 'active'}}" {{action 'setMenu' 'position' position}}>
+                {{titleize position}}
+              </button>
+            {{/each}}
+          </div>
+        </div>
+
+        <div class="option">
+          <label for="locked">Locked</label>
+          <a id="locked" {{action (toggle 'locked' this)}} class="checkbox">
+            <i class="fa {{if locked 'fa-check-square' 'fa-square'}}" aria-hidden="true"></i>
+          </a>
+        </div>
+
+        <div class="option">
+          <label for="translucentOverlay">Translucent Overlay</label>
+          <a id="translucentOverlay" {{action (toggle 'translucentOverlay' this)}} class="checkbox">
+            <i class="fa {{if translucentOverlay 'fa-check-square' 'fa-square'}}" aria-hidden="true"></i>
+          </a>
+        </div>
+
+        <div class="option">
+          <label for="dismissOnClick">Dismiss on Click</label>
+          <a id="dismissOnClick" {{action (toggle 'dismissOnClick' this)}} class="checkbox">
+            <i class="fa {{if dismissOnClick 'fa-check-square' 'fa-square'}}" aria-hidden="true"></i>
+          </a>
+        </div>
+
+        <div class="option">
+          <label for="dismissOnEsc">Dismiss on Escape</label>
+          <a id="dismissOnEsc" {{action (toggle 'dismissOnEsc' this)}} class="checkbox">
+            <i class="fa {{if dismissOnEsc 'fa-check-square' 'fa-square'}}" aria-hidden="true"></i>
+          </a>
+        </div>
+
+        <div class="option">
+          <label for="gesturesEnabled">Gestures Enabled</label>
+          <a id="gesturesEnabled" {{action (toggle 'gesturesEnabled' this)}} class="checkbox">
+            <i class="fa {{if gesturesEnabled 'fa-check-square' 'fa-square'}}" aria-hidden="true"></i>
+          </a>
+        </div>
+      </div>
     </div>
 
-    <div class="option">
-      <label for="translucentOverlay">Translucent Overlay</label>
-      <a id="translucentOverlay" {{action (toggle 'translucentOverlay' this)}} class="checkbox">
-        <i class="fa {{if translucentOverlay 'fa-check-square' 'fa-square'}}" aria-hidden="true"></i>
-      </a>
-    </div>
-
-    <div class="option">
-      <label for="dismissOnClick">Dismiss on Click</label>
-      <a id="dismissOnClick" {{action (toggle 'dismissOnClick' this)}} class="checkbox">
-        <i class="fa {{if dismissOnClick 'fa-check-square' 'fa-square'}}" aria-hidden="true"></i>
-      </a>
-    </div>
-
-    <div class="option">
-      <label for="dismissOnEsc">Dismiss on Escape</label>
-      <a id="dismissOnEsc" {{action (toggle 'dismissOnEsc' this)}} class="checkbox">
-        <i class="fa {{if dismissOnEsc 'fa-check-square' 'fa-square'}}" aria-hidden="true"></i>
-      </a>
+    <div class="inspiration">
+      <p>
+        Inspired by <a href="https://github.com/codrops/SidebarTransitions">Sidebar Transitions</a> by Codrops
+      </p>
     </div>
   </div>
-</div>
-
-<div class="inspiration text-center">
-  <p>
-    Inspired by <a href="https://github.com/codrops/SidebarTransitions">Sidebar Transitions</a> by Codrops
-  </p>
-</div>
+</main>

--- a/tests/integration/components/bm-menu-item-test.js
+++ b/tests/integration/components/bm-menu-item-test.js
@@ -44,3 +44,19 @@ test('dismissOnClick closes the menu', function(assert) {
   this.$('.bm-menu-item').click();
   assert.notOk(this.get('state.open'), 'Menu should be closed');
 });
+
+test('dismissOnClick doesnt close a locked menu', function(assert) {
+  this.render(template);
+
+  let state = this.get('state');
+
+  run(() => state.set('open', true));
+  run(() => state.set('locked', true));
+
+  this.$('.bm-menu-item').click();
+  assert.ok(this.get('state.open'), 'Menu should still be open');
+
+  this.set('dismissOnClick', true);
+  this.$('.bm-menu-item').click();
+  assert.ok(this.get('state.open'), 'Menu should still be open');
+});

--- a/tests/integration/components/burger-menu-test.js
+++ b/tests/integration/components/burger-menu-test.js
@@ -15,7 +15,9 @@ const template = hbs`
     translucentOverlay=translucentOverlay
     dismissOnClick=dismissOnClick
     dismissOnEsc=dismissOnEsc
+    gesturesEnabled=gesturesEnabled
     open=open
+    locked=locked
     as |burger|
   }}
     {{#burger.menu itemTagName="li" as |menu|}}
@@ -57,9 +59,11 @@ moduleForComponent('burger-menu', 'Integration | Component | burger menu', {
   beforeEach() {
     this.setProperties({
       open: false,
+      locked: false,
       translucentOverlay: true,
       dismissOnClick: true,
       dismissOnEsc: true,
+      gesturesEnabled: true,
       state: getOwner(this).lookup('service:burger-menu')
     });
   }
@@ -185,6 +189,27 @@ test('clicking outside of menu doesnt close it -- dismissOnClick = false', funct
   assert.ok(this.$('.ember-burger-menu').hasClass('is-open'), 'Clicking in the content doesnt close the menu');
 });
 
+test('clicking outside of locked menu doesnt close it', function(assert) {
+  this.set('open', true);
+  this.set('locked', true);
+
+  this.render(template);
+
+  assert.ok(this.$('.ember-burger-menu').hasClass('is-open'), 'Menu is open');
+
+  run(() => {
+    this.$('.bm-menu li:first').click();
+  });
+
+  assert.ok(this.$('.ember-burger-menu').hasClass('is-open'), 'Clicking on the menu doesnt close it');
+
+  run(() => {
+    this.$('.bm-content').click();
+  });
+
+  assert.ok(this.$('.ember-burger-menu').hasClass('is-open'), 'Clicking in the content doesnt close the menu');
+});
+
 test('pressing ESC closes the menu -- dismissOnEsc = true', function(assert) {
   this.set('open', true);
 
@@ -202,6 +227,21 @@ test('pressing ESC closes the menu -- dismissOnEsc = true', function(assert) {
 test('pressing ESC doesnt close the menu -- dismissOnEsc = false', function(assert) {
   this.set('open', true);
   this.set('dismissOnEsc', false);
+
+  this.render(template);
+
+  assert.ok(this.$('.ember-burger-menu').hasClass('is-open'), 'Menu is open');
+
+  run(() => {
+    triggerKeyboardEvent(this.$(), 'keyup', KEYS.ESCAPE);
+  });
+
+  assert.ok(this.$('.ember-burger-menu').hasClass('is-open'), 'Menu is open');
+});
+
+test('pressing ESC doesnt close a locked menu', function(assert) {
+  this.set('open', true);
+  this.set('locked', true);
 
   this.render(template);
 
@@ -247,6 +287,33 @@ test('swipe events toggles the menu', function(assert) {
   });
 
   assert.notOk(this.$('.ember-burger-menu').hasClass('is-open'), 'Menu is not open');
+});
+
+test('swipe events dont toggle the menu -- gesturesEnabled = false', function(assert) {
+  this.set('gesturesEnabled', false);
+  this.render(template);
+
+  assert.notOk(this.$('.ember-burger-menu').hasClass('is-open'), 'Menu is not open');
+
+  run(() => {
+    triggerSwipeEvent(this.$('.ember-burger-menu'), 'right');
+  });
+
+  assert.notOk(this.$('.ember-burger-menu').hasClass('is-open'), 'Menu is not open');
+});
+
+test('swipe events dont toggle a locked menu', function(assert) {
+  this.set('open', true);
+  this.set('locked', true);
+  this.render(template);
+
+  assert.ok(this.$('.ember-burger-menu').hasClass('is-open'), 'Menu is open');
+
+  run(() => {
+    triggerSwipeEvent(this.$('.ember-burger-menu'), 'left');
+  });
+
+  assert.ok(this.$('.ember-burger-menu').hasClass('is-open'), 'Menu is open');
 });
 
 test('custom animation', function(assert) {


### PR DESCRIPTION
Resolves #24 

- `locked`

  Lock the menu in its current open / closed state. Please note that changes made
  directly via the burgerMenu service or {{burger.state.actions}} will still propagate.

  **Default: false**

- `gesturesEnabled`

  Whether the menu can be open / closed using gestures. The only available gesture currently is swipe.

  **Default: true**

- [x] Waiting on a new release of rwjblue/ember-lifeline to be able to use removeEventListener