### PR TITLE
resolve a later version of `matches-selector`

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,5 +80,8 @@
   "ember-addon": {
     "configPath": "tests/dummy/config",
     "demoURL": "http://offirgolan.github.io/ember-burger-menu"
+  },
+  "resolutions": {
+    "matches-selector": "^1.0.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6408,9 +6408,10 @@ matcher-collection@^1.0.0, matcher-collection@^1.0.5:
   dependencies:
     minimatch "^3.0.2"
 
-matches-selector@0.0.1:
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/matches-selector/-/matches-selector-0.0.1.tgz#1df5262243ae341c1a0804dd302048267ac713bb"
+matches-selector@0.0.1, matches-selector@^1.0.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/matches-selector/-/matches-selector-1.2.0.tgz#d1814e7e8f43e69d22ac33c9af727dc884ecf12a"
+  integrity sha512-c4vLwYWyl+Ji+U43eU/G5FwxWd4ZH0ePUsFs5y0uwD9HUEFBXUQ1zUUan+78IpRD+y4pUfG0nAzNM292K7ItvA==
 
 math-random@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
Fixes #117 

`closest` depends upon `matches-selector`, which is not node-safe. This uses yarn's `resolutions` feature to force installing a working version which is node-safe.

Updating `closest` wouldn't help, because it pins `matches-selector` to `1.0.0`, and the version we want is `1.2.0`.