### PR TITLE
Drop support for Node12

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "webpack": "^5.73.0"
   },
   "engines": {
-    "node": "12.* || 14.* || >= 16"
+    "node": "14.* || >= 16"
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org"


### PR DESCRIPTION
# Tasks
- Drop support for Node12

I decided to create this pull request because Node12 is no longer in the group of the supported version

![image](https://user-images.githubusercontent.com/17426143/195800510-12561a88-fedb-4f3e-a819-80945b29716d.png)
